### PR TITLE
bump minSdkVersion to 21 to support the one in react-native lib

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -3,7 +3,7 @@
 buildscript {
     ext {
         buildToolsVersion = "29.0.2"
-        minSdkVersion = 16
+        minSdkVersion = 21
         compileSdkVersion = 29
         targetSdkVersion = 29
     }


### PR DESCRIPTION
While building the project for Android, we ran into this exception:
`uses-sdk:minSdkVersion 16 cannot be smaller than version 21 declared in library [com.facebook.react:react-native:0.64.2]`

The solution is to increase the project's minSdk version to at least 21. 

Here is the Android API distribution stats
<img width="1102" alt="Screen Shot 2021-08-13 at 12 48 37 AM" src="https://user-images.githubusercontent.com/10891720/129284018-1857fc94-7539-4135-a2d0-6fb6012dfca0.png">
