### PR TITLE
fix(build): undefined symbol LndmobileWalletKitDeriveKey

### DIFF
--- a/ios/lightning/LndReactModule.m
+++ b/ios/lightning/LndReactModule.m
@@ -185,8 +185,8 @@ RCT_EXPORT_METHOD(start: (RCTPromiseResolveBlock)resolve
                        @"StopDaemon" : ^(NSData* bytes, NativeCallback* cb) { LndmobileStopDaemon(bytes, cb); },
                        @"UpdateChannelPolicy" : ^(NSData* bytes, NativeCallback* cb) { LndmobileUpdateChannelPolicy(bytes, cb); },
                        @"VerifyMessage" : ^(NSData* bytes, NativeCallback* cb) { LndmobileVerifyMessage(bytes, cb); },
-                       @"EstimateFee" : ^(NSData* bytes, NativeCallback* cb) { LndmobileEstimateFee(bytes, cb); },
-                       @"DeriveKey" : ^(NSData* bytes, NativeCallback* cb) { LndmobileWalletKitDeriveKey(bytes, cb);}
+                       @"EstimateFee" : ^(NSData* bytes, NativeCallback* cb) { LndmobileEstimateFee(bytes, cb); }/*,
+                       @"DeriveKey" : ^(NSData* bytes, NativeCallback* cb) { LndmobileWalletKitDeriveKey(bytes, cb);}*/
                        };
   
   self.recvStreamMethods = @{


### PR DESCRIPTION
the iOS build is failing because of:

```
Undefined symbols for architecture armv7
> Symbol: _LndmobileWalletKitDeriveKey
> Referenced from: ___33-[LndReactModule start:rejecter:]_block_invoke_38 in LndReactModule.o
```